### PR TITLE
Work with a byte slice instead of string

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 )
 
-var sample = `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+var (
+	sample = `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
 <HTML>
 <HEAD>
 <TITLE>Sample text for Library of Congress control number 2006051179</TITLE>
@@ -35,9 +36,17 @@ Rome -- History -- Fiction.<br>
 
 </BODY>
 </HTML>`
+	sampleB = []byte(sample)
+)
 
 func BenchmarkCleanContent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		CleanContent(sample, "en", true)
+		CleanString(sample, "en", true)
+	}
+}
+
+func BenchmarkClean(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Clean(sampleB, "en", true)
 	}
 }

--- a/stopwords_test.go
+++ b/stopwords_test.go
@@ -5,6 +5,7 @@
 package stopwords
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -12,13 +13,13 @@ var expected = " abcdefghijk lmnopqrstuvwxyz "
 
 func TestLangCodesHTML(t *testing.T) {
 	var langCodeTests = []struct {
-	  langCode        string
+		langCode string
 	}{
-	  {"en-US"},
-	  {"en_US"},
-	  {"en_GB"},
-	  {"en-GB"},
-	  {"en"},
+		{"en-US"},
+		{"en_US"},
+		{"en_GB"},
+		{"en-GB"},
+		{"en"},
 		{"eng"},
 		{"zz"},
 	}
@@ -26,9 +27,14 @@ func TestLangCodesHTML(t *testing.T) {
 	source := "afterwards"
 	expected2 := " "
 	for _, tt := range langCodeTests {
-		actual := CleanContent(source, tt.langCode, false)
+		actual := CleanString(source, tt.langCode, false)
 		if actual != expected2 {
-			t.Errorf("Test failed, got: '%s'", actual)
+			t.Errorf("string test failed: expected %q, got %q", expected2, actual)
+		}
+
+		actualB := Clean([]byte(source), tt.langCode, false)
+		if !reflect.DeepEqual(actualB, []byte(expected2)) {
+			t.Errorf("bytes test failed: expected %q, got: %q", []byte(expected2), actualB)
 		}
 	}
 }
@@ -36,16 +42,21 @@ func TestLangCodesHTML(t *testing.T) {
 func TestRemoveHTML(t *testing.T) {
 	source := "<a href='resource.htm'>&quot;Fran &amp; Freddie&#39;s Diner&quot;</a>&nbsp;<b>&lt;tasty@example.com&gt;</b>"
 	expected2 := "fran freddie's diner tasty example com "
-	actual := CleanContent(source, "en", true)
+	actual := CleanString(source, "en", true)
 	if actual != expected2 {
-		t.Errorf("Test failed, got: '%s'", actual)
+		t.Errorf("string test failed: expected %q, got %q", expected2, actual)
+	}
+
+	actualB := Clean([]byte(source), "en", true)
+	if !reflect.DeepEqual(actualB, []byte(expected2)) {
+		t.Errorf("bytes test failed: expected %q, got: %q", []byte(expected2), actualB)
 	}
 }
 
 func TestRemoveSpaces(t *testing.T) {
 	source := "ab cd      ef  gh ij     kl         mn      op qr   st uv    wx yz"
 	expected2 := "ab cd ef gh ij kl mn op qr st uv wx yz "
-	actual := CleanContent(source, "en", true)
+	actual := CleanString(source, "en", true)
 	if actual != expected2 {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -54,7 +65,7 @@ func TestRemoveSpaces(t *testing.T) {
 func TestToLower(t *testing.T) {
 	source := "All Problematic ALmoST Always"
 	expected2 := " problematic "
-	actual := CleanContent(source, "en", true)
+	actual := CleanString(source, "en", true)
 	if actual != expected2 {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -62,7 +73,7 @@ func TestToLower(t *testing.T) {
 
 func TestArabicStopWords(t *testing.T) {
 	source := "كلم abcdefghijk واضافت lmnopqrstuvwxyz اليوم"
-	actual := CleanContent(source, "ar", false)
+	actual := CleanString(source, "ar", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -70,7 +81,7 @@ func TestArabicStopWords(t *testing.T) {
 
 func TestBulgarianStopWords(t *testing.T) {
 	source := "беше abcdefghijk въпреки lmnopqrstuvwxyz юмрук"
-	actual := CleanContent(source, "bg", false)
+	actual := CleanString(source, "bg", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -78,7 +89,7 @@ func TestBulgarianStopWords(t *testing.T) {
 
 func TestCzechStopWords(t *testing.T) {
 	source := "ačkoli abcdefghijk chceš lmnopqrstuvwxyz neděláš"
-	actual := CleanContent(source, "cs", false)
+	actual := CleanString(source, "cs", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -86,7 +97,7 @@ func TestCzechStopWords(t *testing.T) {
 
 func TestDanishStopWords(t *testing.T) {
 	source := "før abcdefghijk få lmnopqrstuvwxyz hvornår næste"
-	actual := CleanContent(source, "da", false)
+	actual := CleanString(source, "da", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -94,7 +105,7 @@ func TestDanishStopWords(t *testing.T) {
 
 func TestDutchStopWords(t *testing.T) {
 	source := "aangezien abcdefghijk hierbeneden lmnopqrstuvwxyz ofschoon uitgezonderd"
-	actual := CleanContent(source, "nl", false)
+	actual := CleanString(source, "nl", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -102,7 +113,7 @@ func TestDutchStopWords(t *testing.T) {
 
 func TestEnglishStopWords(t *testing.T) {
 	source := "along abcdefghijk another lmnopqrstuvwxyz yet"
-	actual := CleanContent(source, "en", false)
+	actual := CleanString(source, "en", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -110,7 +121,7 @@ func TestEnglishStopWords(t *testing.T) {
 
 func TestFrenchStopWords(t *testing.T) {
 	source := "assez abcdefghijk certaines lmnopqrstuvwxyz vous-mêmes"
-	actual := CleanContent(source, "fr", false)
+	actual := CleanString(source, "fr", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -118,7 +129,7 @@ func TestFrenchStopWords(t *testing.T) {
 
 func TestFinnishStopWords(t *testing.T) {
 	source := "ylös abcdefghijk vähintään lmnopqrstuvwxyz täytyvät kyllä"
-	actual := CleanContent(source, "fi", false)
+	actual := CleanString(source, "fi", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -126,7 +137,7 @@ func TestFinnishStopWords(t *testing.T) {
 
 func TestGermanStopWords(t *testing.T) {
 	source := "dafür abcdefghijk dementsprechend lmnopqrstuvwxyz großen zwölf"
-	actual := CleanContent(source, "de", false)
+	actual := CleanString(source, "de", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -134,7 +145,7 @@ func TestGermanStopWords(t *testing.T) {
 
 func TestGreekStopWords(t *testing.T) {
 	source := "δαίσ abcdefghijk τοιοῦτοσ lmnopqrstuvwxyz ειστε εκεινουσ"
-	actual := CleanContent(source, "el", false)
+	actual := CleanString(source, "el", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -142,7 +153,7 @@ func TestGreekStopWords(t *testing.T) {
 
 func TestHungarianStopWords(t *testing.T) {
 	source := "alapján abcdefghijk általában lmnopqrstuvwxyz belőle különbözőbb"
-	actual := CleanContent(source, "hu", false)
+	actual := CleanString(source, "hu", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -150,7 +161,7 @@ func TestHungarianStopWords(t *testing.T) {
 
 func TestItalianStopWords(t *testing.T) {
 	source := "ahimè abcdefghijk quantunque lmnopqrstuvwxyz perchè tuttavia"
-	actual := CleanContent(source, "it", false)
+	actual := CleanString(source, "it", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -158,7 +169,7 @@ func TestItalianStopWords(t *testing.T) {
 
 func TestLatvianStopWords(t *testing.T) {
 	source := "būsiet abcdefghijk kļūsim lmnopqrstuvwxyz līdzko tiklīdz"
-	actual := CleanContent(source, "lv", false)
+	actual := CleanString(source, "lv", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -166,7 +177,7 @@ func TestLatvianStopWords(t *testing.T) {
 
 func TestNorwegianStopWords(t *testing.T) {
 	source := "fÅ abcdefghijk tilstand lmnopqrstuvwxyz vÖre gjÛre"
-	actual := CleanContent(source, "no", false)
+	actual := CleanString(source, "no", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -174,7 +185,7 @@ func TestNorwegianStopWords(t *testing.T) {
 
 func TestPersianStopWords(t *testing.T) {
 	source := "شده abcdefghijk شوند lmnopqrstuvwxyz خواهند بنابراين"
-	actual := CleanContent(source, "fa", false)
+	actual := CleanString(source, "fa", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -182,7 +193,7 @@ func TestPersianStopWords(t *testing.T) {
 
 func TestPolishStopWords(t *testing.T) {
 	source := "daleko abcdefghijk dziś lmnopqrstuvwxyz natychmiast każdy"
-	actual := CleanContent(source, "pl", false)
+	actual := CleanString(source, "pl", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -190,7 +201,7 @@ func TestPolishStopWords(t *testing.T) {
 
 func TestPortugueseStopWords(t *testing.T) {
 	source := "aí abcdefghijk área lmnopqrstuvwxyz vocês vão"
-	actual := CleanContent(source, "pt", false)
+	actual := CleanString(source, "pt", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -198,7 +209,7 @@ func TestPortugueseStopWords(t *testing.T) {
 
 func TestRomanianStopWords(t *testing.T) {
 	source := "voastră abcdefghijk ţi lmnopqrstuvwxyz aibă"
-	actual := CleanContent(source, "ro", false)
+	actual := CleanString(source, "ro", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -206,7 +217,7 @@ func TestRomanianStopWords(t *testing.T) {
 
 func TestRussianStopWords(t *testing.T) {
 	source := "многочисленное abcdefghijk меньше lmnopqrstuvwxyz тринадцать третий"
-	actual := CleanContent(source, "ru", false)
+	actual := CleanString(source, "ru", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -214,7 +225,7 @@ func TestRussianStopWords(t *testing.T) {
 
 func TestSpanishStopWords(t *testing.T) {
 	source := "aquél abcdefghijk cómo lmnopqrstuvwxyz día mucho"
-	actual := CleanContent(source, "es", false)
+	actual := CleanString(source, "es", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -222,7 +233,7 @@ func TestSpanishStopWords(t *testing.T) {
 
 func TestSlovakStopWords(t *testing.T) {
 	source := "budú abcdefghijk každý lmnopqrstuvwxyz môže tvojími"
-	actual := CleanContent(source, "sk", false)
+	actual := CleanString(source, "sk", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -230,7 +241,7 @@ func TestSlovakStopWords(t *testing.T) {
 
 func TestSwedishStopWords(t *testing.T) {
 	source := "alltså abcdefghijk åttonde lmnopqrstuvwxyz verkligen likställda"
-	actual := CleanContent(source, "sv", false)
+	actual := CleanString(source, "sv", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}
@@ -238,7 +249,7 @@ func TestSwedishStopWords(t *testing.T) {
 
 func TestTurkishStopWords(t *testing.T) {
 	source := "altmış abcdefghijk yaptığı lmnopqrstuvwxyz ancak beş"
-	actual := CleanContent(source, "tr", false)
+	actual := CleanString(source, "tr", false)
 	if actual != expected {
 		t.Errorf("Test failed, got: '%s'", actual)
 	}


### PR DESCRIPTION
Using `regexp.ReplaceAllString` is very inefficient.  I've refactored the
main clean function to work on a byte slice and called the function `Clean`.
`CleanContent` has been renamed to `CleanString`.

benchmark                 old ns/op     new ns/op     delta
BenchmarkCleanContent     21159375      6637523       -68.63%

benchmark                 old allocs     new allocs     delta
BenchmarkCleanContent     7129           4195           -41.16%

benchmark                 old bytes     new bytes     delta
BenchmarkCleanContent     17182896      598000        -96.52%